### PR TITLE
Инициализация неинициализированных переменных

### DIFF
--- a/GyverCore/cores/arduino/GyverCore_uart.cpp
+++ b/GyverCore/cores/arduino/GyverCore_uart.cpp
@@ -289,8 +289,9 @@ void GyverUart::printHelper(uint32_t data, byte base) {
 
 
 void GyverUart::printBytes(uint32_t data) {
-	int8_t bytes[10];
-	byte amount;
+	int8_t bytes[10] = {};
+	byte amount = 0;
+
 	for (byte i = 0; i < 10; i++) {
 		bytes[i] = data % 10;
 		data /= 10;

--- a/GyverCore/cores/arduino/Stream.h
+++ b/GyverCore/cores/arduino/Stream.h
@@ -60,7 +60,7 @@ class Stream : public Print
     virtual int read() = 0;
     virtual int peek() = 0;
 
-    Stream() {_timeout=1000;}
+    Stream() {_timeout=1000; _startMillis=0;}
 
 // parsing methods
 


### PR DESCRIPTION
В C++ чтение неинициализированных переменных является [неопределённым поведением](https://ru.m.wikipedia.org/wiki/%D0%9D%D0%B5%D0%BE%D0%BF%D1%80%D0%B5%D0%B4%D0%B5%D0%BB%D1%91%D0%BD%D0%BD%D0%BE%D0%B5_%D0%BF%D0%BE%D0%B2%D0%B5%D0%B4%D0%B5%D0%BD%D0%B8%D0%B5). Стоит отметить, что в исправленных местах кода ядра логических ошибок нет, поэтому, такого чтения не происходит. Однако отсутствие начальной инициализации делает код хрупким.