### PR TITLE
Fix compiler warnings

### DIFF
--- a/GyverCore/cores/arduino/Arduino.h
+++ b/GyverCore/cores/arduino/Arduino.h
@@ -225,7 +225,7 @@ uint16_t makeWord(byte h, byte l);
 unsigned long pulseIn(uint8_t pin, uint8_t state, unsigned long timeout = 1000000L);
 unsigned long pulseInLong(uint8_t pin, uint8_t state, unsigned long timeout = 1000000L);
 
-void tone(uint8_t pin , uint16_t freq, uint32_t duration = 0);
+void tone(uint8_t pin , uint16_t freq, uint32_t duration);
 void noTone(uint8_t pin);
 
 // WMath prototypes

--- a/GyverCore/cores/arduino/GyverCore_gpio.cpp
+++ b/GyverCore/cores/arduino/GyverCore_gpio.cpp
@@ -85,6 +85,7 @@ bool digitalRead (uint8_t pin) {
   } else if (pin < 20) {
     return bitRead(PINC, pin - 14);		// Return pin state
   }
+  return false;
 }
 
 


### PR DESCRIPTION
исправленно:
- переопределение параметра по умолчанию в  `void tone()`
- `bool digitalread` не всегда возвращает значение